### PR TITLE
Unify with material to smooth theme switching

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -89,7 +89,7 @@ $input-group-addon-bg:                  $gray-300 !default;
 
 // Navs ========================================================================
 
-$navbar-padding-y:                  1.5rem !default;
+$navbar-padding-y:                  .5rem !default;
 
 $navbar-dark-hover-color:           $white !default;
 


### PR DESCRIPTION
Material uses .5 for navbar y padding, so when switching between themes, the 1.5 padding caused the navbar to overlap other elements. Making the pad the same makes theme changes smoother.